### PR TITLE
Remove Cross-Origin Resource Sharing (CORS) annotation from DriversAs…

### DIFF
--- a/src/main/java/com/gtu/drivers_assignment_management_service/presentation/rest/DriversAssignmentController.java
+++ b/src/main/java/com/gtu/drivers_assignment_management_service/presentation/rest/DriversAssignmentController.java
@@ -18,7 +18,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/assignments")
 @Tag(name = "Drivers Assignment Management", description = "APIs for managing drivers assignment")
-@CrossOrigin(origins = "*")
 public class DriversAssignmentController {
     private final DriversAssignmentUseCase driversAssignmentUseCase;
 


### PR DESCRIPTION
This pull request removes the `@CrossOrigin` annotation from the `DriversAssignmentController` class in the `Drivers Assignment Management Service`. This change eliminates unrestricted cross-origin access for APIs in this controller.…signmentController